### PR TITLE
Write DICOM to file

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,12 @@ Build the JAR artifact:
 $ nix-build
 ```
 
-#### Warning
+> Note: when changing sbt build dependencies, change `depsSha256` in `default.nix` as instructed.
 
-When changing sbt build dependencies, change `depsSha256` in `default.nix` as instructed.
+### CI
+
+CI is handled by GitHub actions, using Nix for dependency management, test, build and caching (with Cachix).
+
+> Note: for CI to run tests, the CI needs the Nix build to run tests in checkPhase.
+
+You can run the CI locally using `act` (provided in the Nix shell).

--- a/build.sbt
+++ b/build.sbt
@@ -18,5 +18,6 @@ libraryDependencies += "org.apache.spark" %% "spark-streaming" % "3.2.0" % "prov
 libraryDependencies += "org.scalactic" %% "scalactic" % "3.2.10"
 libraryDependencies += "org.scalatest" %% "scalatest" % "3.2.10" % "test"
 libraryDependencies += "org.dcm4che" % "dcm4che-core" % "5.24.2"
+libraryDependencies += "org.dcm4che" % "dcm4che-imageio" % "5.24.2"
 
 assembly / mainClass := Some("ai.kaiko.dicom.app.Main")

--- a/build.sbt
+++ b/build.sbt
@@ -9,6 +9,8 @@ Global / excludeLintKeys += idePackagePrefix
 
 resolvers += "dcm4che Repository" at "https://www.dcm4che.org/maven2"
 
+libraryDependencies += "org.apache.logging.log4j" %% "log4j-api-scala" % "11.0"
+libraryDependencies += "org.apache.logging.log4j" % "log4j-core" % "2.14.1"
 libraryDependencies += "org.apache.spark" %% "spark-core" % "3.2.0" % "provided"
 libraryDependencies += "org.apache.spark" %% "spark-sql" % "3.2.0" % "provided"
 libraryDependencies += "org.apache.spark" %% "spark-mllib" % "3.2.0" % "provided"

--- a/default.nix
+++ b/default.nix
@@ -12,7 +12,7 @@ pkgs.sbt.mkDerivation {
   # 1. reset this to "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
   # 2. let Nix compute hash
   # 3. use computed hash here and re-run build
-  depsSha256 = "o9L1axgPcjuzDANgw1PmL4UK2/pffpO88p5YPlmlgIA=";
+  depsSha256 = "9qsfkFejm6OpGzvJah3KWtQ0dxdVFq87sHsIZ9FyOjc=";
 
   src = ./.;
 

--- a/default.nix
+++ b/default.nix
@@ -12,7 +12,7 @@ pkgs.sbt.mkDerivation {
   # 1. reset this to "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
   # 2. let Nix compute hash
   # 3. use computed hash here and re-run build
-  depsSha256 = "9qsfkFejm6OpGzvJah3KWtQ0dxdVFq87sHsIZ9FyOjc=";
+  depsSha256 = "HKok2Mx2I1I75wqGgFQFabl8HvElJUs0a7lttWqk86k=";
 
   src = ./.;
 

--- a/default.nix
+++ b/default.nix
@@ -12,7 +12,12 @@ pkgs.sbt.mkDerivation {
   # 1. reset this to "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
   # 2. let Nix compute hash
   # 3. use computed hash here and re-run build
-  depsSha256 = "HKok2Mx2I1I75wqGgFQFabl8HvElJUs0a7lttWqk86k=";
+  #
+  # Sometimes, the sha256 computed locally is not the same as the one in CI.
+  # In such cases, believe in the CI, it's most likely the right one.
+  # You can run the CI locally using `act` provided in the Nix shell
+  depsSha256 = "JYh/Nh9mXbDOESFdqNtvjxSgNPSckFiQ0rPrJqIHTkY=";
+
 
   src = ./.;
 

--- a/src/main/scala/dicom/DicomHelper.scala
+++ b/src/main/scala/dicom/DicomHelper.scala
@@ -1,0 +1,20 @@
+package ai.kaiko.dicom
+
+import org.dcm4che3.imageio.plugins.dcm.DicomImageReaderSpi
+import org.dcm4che3.io.DicomInputStream
+
+import java.awt.image.BufferedImage
+import java.io.File
+
+object DicomHelper {
+  def readDicomImage(file: File): BufferedImage = {
+    val imgReaderSpi = new DicomImageReaderSpi
+    val imgReader = imgReaderSpi.createReaderInstance(null)
+
+    val dicomIn = new DicomInputStream(file)
+    imgReader.setInput(dicomIn)
+    val numImg = imgReader.getNumImages(true)
+    val imgReadParam = imgReader.getDefaultReadParam
+    imgReader.read(0, null)
+  }
+}

--- a/src/main/scala/spark/dicom/DicomFileFormat.scala
+++ b/src/main/scala/spark/dicom/DicomFileFormat.scala
@@ -1,6 +1,5 @@
 package ai.kaiko.spark.dicom
 
-import ai.kaiko.spark.dicom.DicomOutputWriter
 import ai.kaiko.spark.dicom.v2.DicomWrite
 import com.google.common.io.ByteStreams
 import com.google.common.io.Closeables

--- a/src/main/scala/spark/dicom/DicomFileFormat.scala
+++ b/src/main/scala/spark/dicom/DicomFileFormat.scala
@@ -1,16 +1,21 @@
 package ai.kaiko.spark.dicom
 
+import ai.kaiko.spark.dicom.DicomOutputWriter
+import ai.kaiko.spark.dicom.v2.DicomWrite
 import com.google.common.io.ByteStreams
 import com.google.common.io.Closeables
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.FileStatus
 import org.apache.hadoop.fs.Path
 import org.apache.hadoop.mapreduce.Job
+import org.apache.hadoop.mapreduce.TaskAttemptContext
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.codegen.UnsafeRowWriter
 import org.apache.spark.sql.errors.QueryExecutionErrors
+import org.apache.spark.sql.execution.datasources.CodecStreams
 import org.apache.spark.sql.execution.datasources.FileFormat
+import org.apache.spark.sql.execution.datasources.OutputWriter
 import org.apache.spark.sql.execution.datasources.OutputWriterFactory
 import org.apache.spark.sql.execution.datasources.PartitionedFile
 import org.apache.spark.sql.internal.SQLConf.SOURCES_BINARY_FILE_MAX_LENGTH
@@ -19,7 +24,9 @@ import org.apache.spark.sql.sources.Filter
 import org.apache.spark.sql.types._
 import org.apache.spark.unsafe.types.UTF8String
 import org.apache.spark.util.SerializableConfiguration
+import org.dcm4che3.data.UID
 import org.dcm4che3.io.DicomInputStream
+import org.dcm4che3.io.DicomOutputStream
 
 import java.net.URI
 
@@ -48,13 +55,6 @@ class DicomFileFormat
       options: Map[String, String],
       files: Seq[FileStatus]
   ): Option[StructType] = Some(SCHEMA)
-
-  override def prepareWrite(
-      sparkSession: SparkSession,
-      job: Job,
-      options: Map[String, String],
-      dataSchema: StructType
-  ): OutputWriterFactory = ???
 
   override protected def buildReader(
       sparkSession: SparkSession,
@@ -111,6 +111,26 @@ class DicomFileFormat
       }
 
       Iterator.single(writer.getRow)
+    }
+  }
+
+  override def prepareWrite(
+      sparkSession: SparkSession,
+      job: Job,
+      options: Map[String, String],
+      dataSchema: StructType
+  ): OutputWriterFactory = {
+    new OutputWriterFactory() {
+
+      override def getFileExtension(context: TaskAttemptContext): String =
+        ".dcm"
+
+      def newInstance(
+          path: String,
+          dataSchema: StructType,
+          context: TaskAttemptContext
+      ): OutputWriter = new DicomOutputWriter(path, dataSchema, context)
+
     }
   }
 

--- a/src/main/scala/spark/dicom/DicomOutputWriter.scala
+++ b/src/main/scala/spark/dicom/DicomOutputWriter.scala
@@ -1,0 +1,45 @@
+package ai.kaiko.spark.dicom
+
+import org.apache.hadoop.fs.Path
+import org.apache.hadoop.mapreduce.TaskAttemptContext
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.csv.CSVOptions
+import org.apache.spark.sql.catalyst.csv.UnivocityGenerator
+import org.apache.spark.sql.execution.datasources.CodecStreams
+import org.apache.spark.sql.execution.datasources.OutputWriter
+import org.apache.spark.sql.types.StructType
+import org.dcm4che3.data.UID
+import org.dcm4che3.io.DicomInputStream
+import org.dcm4che3.io.DicomOutputStream
+
+import java.io.ByteArrayOutputStream
+import java.nio.charset.Charset
+
+class DicomOutputWriter(
+    val path: String,
+    dataSchema: StructType,
+    context: TaskAttemptContext
+) extends OutputWriter
+    with Logging {
+
+  val writer = {
+    new DicomOutputStream(
+      CodecStreams.createOutputStream(context, new Path(path)),
+      UID.ExplicitVRLittleEndian
+    )
+  }
+
+  override def write(row: InternalRow): Unit = {
+    val contentColIndex =
+      dataSchema.fields.indexWhere(_.name == DicomFileFormat.CONTENT)
+    if (contentColIndex == -1)
+      throw new Exception(
+        "Missing column '" + DicomFileFormat.CONTENT + "'"
+      )
+    val content = row.getBinary(contentColIndex)
+    writer.write(content)
+  }
+
+  override def close(): Unit = writer.close()
+}

--- a/src/main/scala/spark/dicom/v2/DicomTable.scala
+++ b/src/main/scala/spark/dicom/v2/DicomTable.scala
@@ -15,6 +15,12 @@ import org.apache.spark.sql.execution.datasources.v2.FileTable
 import org.apache.spark.sql.connector.write.{LogicalWriteInfo, WriteBuilder}
 import org.apache.hadoop.fs.FileStatus
 import ai.kaiko.spark.dicom.DicomFileFormat
+import org.apache.spark.sql.connector.write.{
+  LogicalWriteInfo,
+  Write,
+  WriteBuilder
+}
+import org.apache.spark.sql.types.DataType
 
 case class DicomTable(
     name: String,
@@ -31,7 +37,16 @@ case class DicomTable(
   override def inferSchema(files: Seq[FileStatus]): Option[StructType] =
     Some(DicomFileFormat.SCHEMA)
 
-  override def newWriteBuilder(x$1: LogicalWriteInfo): WriteBuilder = ???
+  override def newWriteBuilder(info: LogicalWriteInfo): WriteBuilder =
+    new WriteBuilder {
+      override def build(): Write =
+        DicomWrite(paths, formatName, supportsDataType, info)
+    }
+
+  override def supportsDataType(dataType: DataType): Boolean = dataType match {
+    // accept all data types for now
+    case _ => true
+  }
 
   override def formatName: String = "DICOM"
 }

--- a/src/main/scala/spark/dicom/v2/DicomWrite.scala
+++ b/src/main/scala/spark/dicom/v2/DicomWrite.scala
@@ -1,0 +1,43 @@
+package ai.kaiko.spark.dicom.v2
+
+import ai.kaiko.spark.dicom.DicomOutputWriter
+import org.apache.hadoop.mapreduce.Job
+import org.apache.hadoop.mapreduce.TaskAttemptContext
+import org.apache.spark.sql.connector.write.LogicalWriteInfo
+import org.apache.spark.sql.execution.datasources.OutputWriter
+import org.apache.spark.sql.execution.datasources.OutputWriterFactory
+import org.apache.spark.sql.execution.datasources.v2.FileWrite
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.types.DataType
+import org.apache.spark.sql.types.StructType
+
+case class DicomWrite(
+    paths: Seq[String],
+    formatName: String,
+    supportsDataType: DataType => Boolean,
+    info: LogicalWriteInfo
+) extends FileWrite {
+
+  override def prepareWrite(
+      sqlConf: SQLConf,
+      job: Job,
+      options: Map[String, String],
+      dataSchema: StructType
+  ): OutputWriterFactory = {
+    val conf = job.getConfiguration
+
+    new OutputWriterFactory {
+      override def newInstance(
+          path: String,
+          dataSchema: StructType,
+          context: TaskAttemptContext
+      ): OutputWriter = {
+        new DicomOutputWriter(path, dataSchema, context)
+      }
+
+      override def getFileExtension(context: TaskAttemptContext) = ".dcm"
+
+    }
+  }
+
+}

--- a/src/test/scala/dicom/TestDicomHelper.scala
+++ b/src/test/scala/dicom/TestDicomHelper.scala
@@ -1,0 +1,26 @@
+package ai.kaiko.dicom
+
+import org.apache.log4j.Level
+import org.apache.log4j.LogManager
+import org.scalatest._
+import org.scalatest.flatspec.AnyFlatSpec
+
+import java.io.File
+
+import funspec._
+
+class TestDicomFile extends AnyFlatSpec {
+
+  val logger = LogManager.getLogger(classOf[TestDicomFile].getName);
+  logger.setLevel(Level.DEBUG)
+
+  val SOME_DICOM_FILEPATH =
+    "src/test/resources/Pancreatic-CT-CBCT-SEG/Pancreas-CT-CB_001/07-06-2012-NA-PANCREAS-59677/201.000000-PANCREAS DI iDose 3-97846/1-001.dcm"
+
+  "Dicom" should "be read" in {
+    val file = new File(SOME_DICOM_FILEPATH)
+    assert(file.exists)
+    val img = DicomHelper.readDicomImage(file)
+    assert(img !== null)
+  }
+}

--- a/src/test/scala/spark/dicom/TestDicomFileFormat.scala
+++ b/src/test/scala/spark/dicom/TestDicomFileFormat.scala
@@ -1,6 +1,8 @@
 package ai.kaiko.spark.dicom
 
 import org.apache.hadoop.shaded.org.eclipse.jetty.websocket.common.frames.DataFrame
+import org.apache.log4j.Level
+import org.apache.log4j.LogManager
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.streaming.Trigger
@@ -17,7 +19,7 @@ import funspec._
 trait WithSpark {
   var spark = {
     val spark = SparkSession.builder.master("local").getOrCreate
-    spark.sparkContext.setLogLevel("ERROR")
+    spark.sparkContext.setLogLevel(Level.ERROR.toString())
     spark
   }
 }
@@ -26,6 +28,9 @@ class TestDicomFileFormat
     extends AnyFlatSpec
     with WithSpark
     with BeforeAndAfterAll {
+
+  val logger = LogManager.getLogger("TestDicomFileFormat");
+  logger.setLevel(Level.DEBUG)
 
   override protected def afterAll(): Unit = {
     spark.stop
@@ -38,7 +43,7 @@ class TestDicomFileFormat
         "src/test/resources/Pancreatic-CT-CBCT-SEG/Pancreas-CT-CB_001/07-06-2012-NA-PANCREAS-59677/1.000000-BSCBLLLRSDCB-27748/1-1.dcm"
       )
       .select("path", "length", "content")
-    df.show
+    assert(df.first().getAs[Long]("length") == 2384336)
   }
 
   "Spark" should "stream DICOM files" in {
@@ -46,7 +51,7 @@ class TestDicomFileFormat
       .schema(DicomFileFormat.SCHEMA)
       .format("dicom")
       .load(
-        "src/test/resources/Pancreatic-CT-CBCT-SEG/Pancreas-CT-CB_001/*/*/*"
+        "src/test/resources/Pancreatic-CT-CBCT-SEG/Pancreas-CT-CB_001/07-06-2012-NA-PANCREAS-59677/201.000000-PANCREAS DI iDose 3-97846/*"
       )
 
     val queryName = "testStreamDicom"
@@ -57,7 +62,8 @@ class TestDicomFileFormat
       .start
 
     query.processAllAvailable
-    spark.table(queryName).show
+    val outDf = spark.table(queryName)
+    assert(outDf.count() == 79)
   }
 
   "Spark" should "write a DICOM file" in {
@@ -69,8 +75,13 @@ class TestDicomFileFormat
       .select("path", "length", "content")
 
     val tmpDir = Files.createTempDirectory("some-dicom-files").toFile
-    val outFile = tmpDir.toPath().resolve("1-1.dcm")
+    tmpDir.delete // need to delete since Spark handles creation
 
-    df.repartition(1).write.format("dicom").save(outFile.toString)
+    df.repartition(1)
+      .write
+      .format("dicom")
+      .save(tmpDir.toPath.toString)
+
+    logger.info("Write out to : " + tmpDir.toPath.toAbsolutePath.toString)
   }
 }

--- a/src/test/scala/spark/dicom/TestDicomFileFormat.scala
+++ b/src/test/scala/spark/dicom/TestDicomFileFormat.scala
@@ -4,52 +4,73 @@ import org.apache.hadoop.shaded.org.eclipse.jetty.websocket.common.frames.DataFr
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.streaming.Trigger
+import org.scalatest._
 import org.scalatest.flatspec.AnyFlatSpec
 
+import java.nio.file.Files
 import scala.collection.mutable.MutableList
 import scala.io.BufferedSource
 import scala.io.Source
 
-class TestDicomFileFormat extends AnyFlatSpec {
-  "Spark" should "read DICOM files" in {
+import funspec._
+
+trait WithSpark {
+  var spark = {
     val spark = SparkSession.builder.master("local").getOrCreate
     spark.sparkContext.setLogLevel("ERROR")
-    try {
-      val df = spark.read
-        .format("dicom")
-        .load(
-          "src/test/resources/Pancreatic-CT-CBCT-SEG/Pancreas-CT-CB_001/07-06-2012-NA-PANCREAS-59677/1.000000-BSCBLLLRSDCB-27748/1-1.dcm"
-        )
-        .select("path", "length", "content")
-      df.show
-    } finally {
-      spark.stop
-    }
+    spark
+  }
+}
+
+class TestDicomFileFormat
+    extends AnyFlatSpec
+    with WithSpark
+    with BeforeAndAfterAll {
+
+  override protected def afterAll(): Unit = {
+    spark.stop
+  }
+
+  "Spark" should "read DICOM files" in {
+    val df = spark.read
+      .format("dicom")
+      .load(
+        "src/test/resources/Pancreatic-CT-CBCT-SEG/Pancreas-CT-CB_001/07-06-2012-NA-PANCREAS-59677/1.000000-BSCBLLLRSDCB-27748/1-1.dcm"
+      )
+      .select("path", "length", "content")
+    df.show
   }
 
   "Spark" should "stream DICOM files" in {
-    val spark = SparkSession.builder.master("local").getOrCreate
-    spark.sparkContext.setLogLevel("ERROR")
-    try {
-      val df = spark.readStream
-        .schema(DicomFileFormat.SCHEMA)
-        .format("dicom")
-        .load(
-          "src/test/resources/Pancreatic-CT-CBCT-SEG/Pancreas-CT-CB_001/*/*/*"
-        )
+    val df = spark.readStream
+      .schema(DicomFileFormat.SCHEMA)
+      .format("dicom")
+      .load(
+        "src/test/resources/Pancreatic-CT-CBCT-SEG/Pancreas-CT-CB_001/*/*/*"
+      )
 
-      val queryName = "testStreamDicom"
-      val query = df.writeStream
-        .trigger(Trigger.Once)
-        .format("memory")
-        .queryName(queryName)
-        .start
+    val queryName = "testStreamDicom"
+    val query = df.writeStream
+      .trigger(Trigger.Once)
+      .format("memory")
+      .queryName(queryName)
+      .start
 
-      query.processAllAvailable
-      spark.table(queryName).show
+    query.processAllAvailable
+    spark.table(queryName).show
+  }
 
-    } finally {
-      spark.stop
-    }
+  "Spark" should "write a DICOM file" in {
+    val df = spark.read
+      .format("dicom")
+      .load(
+        "src/test/resources/Pancreatic-CT-CBCT-SEG/Pancreas-CT-CB_001/07-06-2012-NA-PANCREAS-59677/1.000000-BSCBLLLRSDCB-27748/1-1.dcm"
+      )
+      .select("path", "length", "content")
+
+    val tmpDir = Files.createTempDirectory("some-dicom-files").toFile
+    val outFile = tmpDir.toPath().resolve("1-1.dcm")
+
+    df.repartition(1).write.format("dicom").save(outFile.toString)
   }
 }


### PR DESCRIPTION
This PR allows to write to `.dcm` files from a Spark Dataframe

Unfortunately, it does not seem to be possible to automatically write one file per row, so we'll need to pay attention when writing scripts that export data.
See the test file for demonstration.