### PR TITLE
Ingest DICOM even when fields are null in dataset

### DIFF
--- a/src/main/scala/spark/dicom/DicomSparkMapper.scala
+++ b/src/main/scala/spark/dicom/DicomSparkMapper.scala
@@ -69,17 +69,26 @@ object DicomSparkMapper {
       case FL | FD =>
         DicomSparkMapper(
           sparkDataType = ArrayType(DoubleType, false),
-          reader = (attrs, tag) => ArrayData.toArrayData(attrs.getDoubles(tag))
+          reader = (attrs, tag) =>
+            ArrayData.toArrayData(
+              Option(attrs.getDoubles(tag)).getOrElse(Array.empty)
+            )
         )
       case SL | SS | US | UL =>
         DicomSparkMapper(
           sparkDataType = ArrayType(IntegerType, false),
-          reader = (attrs, tag) => ArrayData.toArrayData(attrs.getInts(tag))
+          reader = (attrs, tag) =>
+            ArrayData.toArrayData(
+              Option(attrs.getInts(tag)).getOrElse(Array.empty)
+            )
         )
       case SV | UV =>
         DicomSparkMapper(
           sparkDataType = ArrayType(LongType, false),
-          reader = (attrs, tag) => ArrayData.toArrayData(attrs.getLongs(tag))
+          reader = (attrs, tag) =>
+            ArrayData.toArrayData(
+              Option(attrs.getLongs(tag)).getOrElse(Array.empty)
+            )
         )
       case DA =>
         DicomSparkMapper(

--- a/src/test/scala/spark/dicom/TestDicomSparkMapper.scala
+++ b/src/test/scala/spark/dicom/TestDicomSparkMapper.scala
@@ -125,6 +125,13 @@ class TestDicomSparkMapper extends AnyFunSpec {
               writer(mutableRow, value)
               assert { mutableRow.get(0, mapper.sparkDataType) === value }
             }
+            it("ingests to InternalRow even when value is null") {
+              val mutableRow = new GenericInternalRow(1)
+              val value = mapper.reader(new Attributes(), tag)
+              val writer = InternalRow.getWriter(0, mapper.sparkDataType)
+              writer(mutableRow, value)
+              assert { mutableRow.get(0, mapper.sparkDataType) === value }
+            }
           }
         }
         case None =>


### PR DESCRIPTION
This PR ensures we can read tags even when the value in the DICOM is not set.