### PR TITLE
Select keywords

### DIFF
--- a/src/main/scala/dicom/DicomStandardDictionary.scala
+++ b/src/main/scala/dicom/DicomStandardDictionary.scala
@@ -66,4 +66,7 @@ object DicomStandardDictionary {
 
   lazy val keywordMap: Map[String, DicomStdElem] =
     elements.map(stdElem => stdElem.keyword -> stdElem).toMap
+
+  lazy val tagMap: Map[Int, DicomStdElem] =
+    elements.map(stdElem => stdElem.tag -> stdElem).toMap
 }

--- a/src/test/scala/spark/dicom/TestDicomDataSource.scala
+++ b/src/test/scala/spark/dicom/TestDicomDataSource.scala
@@ -115,6 +115,18 @@ class TestDicomDataSource
         // abs vr rel path
         assert(row.getAs[String]("path").endsWith(SOME_DICOM_FILEPATH))
       }
+      it("list of defined keywords") {
+        val df = spark.read
+          .format("dicomFile")
+          .load(SOME_DICOM_FILEPATH)
+          .select("keywords")
+
+        val row = df.first
+        val keywords = row.getList[String](row.fieldIndex("keywords"))
+
+        assert(keywords.contains(keywordOf(Tag.PatientName)))
+        assert(!keywords.contains(keywordOf(Tag.XRay3DAcquisitionSequence)))
+      }
     }
 
     it(


### PR DESCRIPTION
This PR allows to select a column "keywords" which is the list of all keyword of standard tags (as defined in the standard DICOM registry) set in the DICOM file