### PR TITLE
Check license headers

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,3 +25,10 @@ jobs:
         with:
           name: nix-build result JARs
           path: result/jars/
+  check-license:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Check license headers
+        run: bash scripts/check_license_headers.sh

--- a/scripts/check_license_headers.sh
+++ b/scripts/check_license_headers.sh
@@ -1,0 +1,11 @@
+set -e
+echo "Checking that a Apache 2 license header is present at the top of all scala files in src/"
+
+src_files_with_missing_license=$(find src -type f -name '*.scala' -exec bash -c '[ ! -z "$(head -1 {} | grep -v "// Licensed to the Apache Software Foundation (ASF) under one")" ] && echo "{}"' \;)
+if [ ! -z "$src_files_with_missing_license" ]
+then
+    echo "Found unlicensed files!"
+    echo $src_files_with_missing_license
+    exit 1
+fi
+echo "All ok"

--- a/scripts/check_license_headers.sh
+++ b/scripts/check_license_headers.sh
@@ -2,7 +2,7 @@ set -e
 echo "Checking that a Apache 2 license header is present at the top of all scala files in src/"
 
 src_files_with_missing_license=$(find src -type f -name '*.scala' -exec bash -c '[ ! -z "$(head -1 {} | grep -v "// Licensed to the Apache Software Foundation (ASF) under one")" ] && echo "{}"' \;)
-if [ ! -z "$src_files_with_missing_license" ]
+if [ "$src_files_with_missing_license" ]
 then
     echo "Found unlicensed files!"
     echo $src_files_with_missing_license

--- a/src/main/scala/spark/dicom/v2/DicomDataSource.scala
+++ b/src/main/scala/spark/dicom/v2/DicomDataSource.scala
@@ -1,3 +1,19 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
 package ai.kaiko.spark.dicom.v2
 
 import ai.kaiko.dicom.DicomStandardDictionary

--- a/src/main/scala/spark/dicom/v2/DicomPartitionReaderFactory.scala
+++ b/src/main/scala/spark/dicom/v2/DicomPartitionReaderFactory.scala
@@ -1,3 +1,19 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
 package ai.kaiko.spark.dicom.v2
 
 import ai.kaiko.spark.dicom.DicomFileReader

--- a/src/main/scala/spark/dicom/v2/DicomScan.scala
+++ b/src/main/scala/spark/dicom/v2/DicomScan.scala
@@ -1,3 +1,19 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
 package ai.kaiko.spark.dicom.v2
 
 import org.apache.spark.sql.SparkSession

--- a/src/main/scala/spark/dicom/v2/DicomScanBuilder.scala
+++ b/src/main/scala/spark/dicom/v2/DicomScanBuilder.scala
@@ -1,3 +1,19 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
 package ai.kaiko.spark.dicom.v2
 
 import org.apache.spark.sql.SparkSession

--- a/src/main/scala/spark/dicom/v2/DicomTable.scala
+++ b/src/main/scala/spark/dicom/v2/DicomTable.scala
@@ -1,3 +1,19 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
 package ai.kaiko.spark.dicom.v2
 
 import org.apache.hadoop.fs.FileStatus


### PR DESCRIPTION
This PR adds a script and a new job to CI to check that all source code (`src/**/*.scala`) files start with a Apache 2 license header