### PR TITLE
Fix #29: recover upon reading non-DICOM file

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ In order to be able to select the `PixelData` column, please turn the `includePi
 spark.read.format("dicomFile").option("includePixelData", true).load("/some/hdfs/path").select("PixelData")
 ```
 
+### Other columns
+
+- `isDicom`: `true` if file was read as a DICOM file, `false` otherwise
+
 ## Development
 
 ### Development shell
@@ -70,15 +74,16 @@ You can run the CI locally using `act` (provided in the Nix shell).
 
 ## Release
 
-Creating a release is done with the help of the [sbt-sonatype](https://github.com/xerial/sbt-sonatype), [sbt-pgp](https://github.com/sbt/sbt-pgp) and [sbt-release](https://github.com/sbt/sbt-release) plugins. 
+Creating a release is done with the help of the [sbt-sonatype](https://github.com/xerial/sbt-sonatype), [sbt-pgp](https://github.com/sbt/sbt-pgp) and [sbt-release](https://github.com/sbt/sbt-release) plugins.
 
-Before starting, make sure to set the [Sonatype credentials](https://github.com/xerial/sbt-sonatype#homesbtsbt-version-013-or-10sonatypesbt) as environment variables: `SONATYPE_USERNAME` & `SONATYPE_PASSWORD`. In addition, make sure to have the `gpg` utility installed and the release GPG Key available in your keyring. 
+Before starting, make sure to set the [Sonatype credentials](https://github.com/xerial/sbt-sonatype#homesbtsbt-version-013-or-10sonatypesbt) as environment variables: `SONATYPE_USERNAME` & `SONATYPE_PASSWORD`. In addition, make sure to have the `gpg` utility installed and the release GPG Key available in your keyring.
 
 Then, run:
+
 ```
 $ nix-shell
 $ sbt
 $ release
 ```
 
-You will be prompted for the "release version", the "next version" and the GPG Key passphrase. Make sure to follow the [SemVer](https://www.scala-lang.org/blog/2021/02/16/preventing-version-conflicts-with-versionscheme.html) versioning scheme. If all went well, the new release should be available on [Maven Central](https://search.maven.org/artifact/ai.kaiko/spark-dicom) in 10 minutes. 
+You will be prompted for the "release version", the "next version" and the GPG Key passphrase. Make sure to follow the [SemVer](https://www.scala-lang.org/blog/2021/02/16/preventing-version-conflicts-with-versionscheme.html) versioning scheme. If all went well, the new release should be available on [Maven Central](https://search.maven.org/artifact/ai.kaiko/spark-dicom) in 10 minutes.

--- a/src/test/resources/nonDicom/test.txt
+++ b/src/test/resources/nonDicom/test.txt
@@ -1,0 +1,1 @@
+This file is not a DICOM file

--- a/src/test/scala/spark/dicom/TestDicomDataSource.scala
+++ b/src/test/scala/spark/dicom/TestDicomDataSource.scala
@@ -57,6 +57,8 @@ object TestDicomDataSource {
 
   val SOME_DICOM_FOLDER_FILEPATH =
     "src/test/resources/Pancreatic-CT-CBCT-SEG/Pancreas-CT-CB_001/07-06-2012-NA-PANCREAS-59677/201.000000-PANCREAS DI iDose 3-97846/*"
+
+  val SOME_NONDICOM_FILEPATH = "src/test/resources/nonDicom/test.txt"
 }
 
 class TestDicomDataSource
@@ -219,6 +221,18 @@ class TestDicomDataSource
       val outDf =
         spark.table(queryName).select("path", keywordOf(Tag.PatientName))
       assert(outDf.count == 79)
+    }
+
+    it("doesn't fail upon reading a non-DICOM file") {
+      val df = spark.read
+        .format("dicomFile")
+        .load(SOME_NONDICOM_FILEPATH)
+        .select("path", "isDicom")
+
+      val row = df.first
+
+      assert(row.getAs[String]("path").endsWith(SOME_NONDICOM_FILEPATH))
+      assert(!row.getAs[Boolean]("isDicom"))
     }
   }
 }


### PR DESCRIPTION
This PR makes a read Job not fail when the data source meets a non DICOM file.
Instead of failing, `false` is written to the `isDicom` column.