### PR TITLE
Shellcheck *.sh files in the CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,4 +45,4 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Check license headers
-        run: bash scripts/check_license_headers.sh
+        run: ./scripts/check_license_headers.sh

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,6 +39,15 @@ jobs:
         run: nix-shell --run "scalafmt --test"
       - name: Lint (scalafix)
         run: nix-shell --run "sbt 'scalafix -r OrganizeImports --check'"
+  shellcheck:
+    runs-on: ubuntu-latest
+    container:
+        image: koalaman/shellcheck-alpine:v0.8.0@sha256:7d818fda19f5d8658fbb61b53f106cde88eda4b977b1db916ad9d3ccfa1c3ac6
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Shellcheck scripts
+        run: ./scripts/shellcheck_all.sh
   check-license:
     runs-on: ubuntu-latest
     steps:

--- a/scripts/check_license_headers.sh
+++ b/scripts/check_license_headers.sh
@@ -1,11 +1,13 @@
+#!/usr/bin/env bash
+
 set -e
 echo "Checking that a Apache 2 license header is present at the top of all scala files in src/"
 
-src_files_with_missing_license=$(find src -type f -name '*.scala' -exec bash -c '[ ! -z "$(head -1 {} | grep -v "// Licensed to the Apache Software Foundation (ASF) under one")" ] && echo "{}"' \;)
+src_files_with_missing_license=$(find src -type f -name '*.scala' -exec bash -c '[ ! -z "$(head -1 "$1" | grep -v "// Licensed to the Apache Software Foundation (ASF) under one")" ] && echo "$1"' shell {} \;)
 if [ "$src_files_with_missing_license" ]
 then
     echo "Found unlicensed files!"
-    echo $src_files_with_missing_license
+    echo "$src_files_with_missing_license"
     exit 1
 fi
 echo "All ok"

--- a/scripts/shellcheck_all.sh
+++ b/scripts/shellcheck_all.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env sh
+#
+# Runs shellcheck on all *.sh files. This script uses sh because
+# the shellcheck-alpine image doesn't have bash (in the CI).
+
+set -e
+command -v shellcheck || { echo "shellcheck not found. Please install it: https://github.com/koalaman/shellcheck"; exit 1; }
+
+scripts=$(find . -name "*.sh") # We look for all scripts, to ensure
+# newly written scripts get automatically checked.
+set +e  # so that the loop below doesn't stop at the first error and all errors
+# are reported at once
+
+rc="0"
+
+for script in $scripts # In a loop, for more readable output
+do
+  echo "shellcheck $script"
+  shellcheck "$script" || rc="$?"
+done
+
+exit "$rc"


### PR DESCRIPTION
This PR adds a step to the CI that runs [shellcheck](https://github.com/koalaman/shellcheck) on all *.sh scripts of the repo. Shellcheck is the standard tool for ensuring the quality of shell scripts and there are docker images readily available for running it in the CI, making this a low-hanging fruit for keeping the quality of scripts high. The new CI step automatically applies to newly added scripts.

To test this MR locally:

* Install shellcheck
* Break an existing script, for example replace `echo "shellcheck $script"` by `echo $script` in `scripts/shellcheck_all.sh`
* Run `./scripts/shellcheck_all.sh`, witness it shows an error and returns a non-zero error code.

Check that I didn't break `check_licence_headers.sh`:

* Break a license header, for example remove the first line of `src/main/scala/dicom/ScalaVR.scala`
* Run `./scripts/check_licence_headers.sh`, witness it fails, as expected.

I have tested this MR on the CI, see [this run](https://github.com/smelc/spark-dicom/runs/5785947624?check_suite_focus=true) where I had broken the script `./scripts/check_license_headers.sh`.